### PR TITLE
fix divide by zero bug

### DIFF
--- a/stochasticity/example3/sis.R
+++ b/stochasticity/example3/sis.R
@@ -2,7 +2,7 @@ beta <- user(0.5) # contact rate
 sigma <- user(0.3) # recovery
 N <- user(1000)  # total population.
 
-is_I_init_at_steady_state <- user(TRUE)
+initialise_at_steady_state <- user(TRUE)
 
 I_init <- user(1)
 
@@ -13,11 +13,11 @@ dt <- 0.01
 time <- step * dt
 
 ## Deterministic solution
-I_det <- if (is_I_init_at_steady_state > 0) 
+I_det <- if (initialise_at_steady_state) 
   I_star / (1 + (I_star / I_det_init - 1) * exp(-(beta - sigma) * time)) else 0
 
 ## Stochastic solution
-initial(I) <- if (is_I_init_at_steady_state > 0) round(I_star) else I_init
+initial(I) <- if (initialise_at_steady_state) round(I_star) else I_init
 
 FOI <- beta * I / N
 S <- N - I

--- a/stochasticity/example3/sis.R
+++ b/stochasticity/example3/sis.R
@@ -2,7 +2,7 @@ beta <- user(0.5) # contact rate
 sigma <- user(0.3) # recovery
 N <- user(1000)  # total population.
 
-I_init_at_steady_state <- user(1)
+is_I_init_at_steady_state <- user(TRUE)
 
 I_init <- user(1)
 
@@ -13,11 +13,11 @@ dt <- 0.01
 time <- step * dt
 
 ## Deterministic solution
-I_det_init <- if (I_init_at_steady_state > 0) I_star else I_init
-output(I_det) <- I_star / (1 + (I_star / I_det_init - 1) * exp(-(beta - sigma) * time))
+I_det <- if (is_I_init_at_steady_state > 0) 
+  I_star / (1 + (I_star / I_det_init - 1) * exp(-(beta - sigma) * time)) else 0
 
 ## Stochastic solution
-initial(I) <- if (I_init_at_steady_state > 0) round(I_star) else I_init
+initial(I) <- if (is_I_init_at_steady_state > 0) round(I_star) else I_init
 
 FOI <- beta * I / N
 S <- N - I
@@ -28,5 +28,5 @@ n_recoveries <- rbinom(I, sigma * dt)
 update(I) <- I + n_infections - n_recoveries
 output(S) <- TRUE
 output(time) <- TRUE
-
+output(I_det) <- TRUE
 output(extinct) <- I == 0


### PR DESCRIPTION
- rename I_init_at_steady_state -> initialise_at_steady_state to clarify this is logical
- fix divide by zero bug causing model crash when simulation is started at steady state but recovery rate > transmission rate (I_det should be 0 here but it was NaN)
@pwinskill @JamesTruscott this will also apply to your practical
